### PR TITLE
Devices enumeration: workaround for MacOS

### DIFF
--- a/ledgercomm/interfaces/hid_device.py
+++ b/ledgercomm/interfaces/hid_device.py
@@ -88,7 +88,8 @@ class HID(Comm):
 
         if len(devices) > 1:
             LOG.warn(
-                "More than one Ledger device with vendor_id %s, will pick the first one", hex(vendor_id))
+                "More than one Ledger device with vendor_id %s, will pick the first one",
+                hex(vendor_id))
 
             # First, we sort by "path", so that the order is deterministic
             devices = sorted(devices, key=lambda device: device["path"])

--- a/ledgercomm/interfaces/hid_device.py
+++ b/ledgercomm/interfaces/hid_device.py
@@ -83,8 +83,11 @@ class HID(Comm):
 
         # On MacOS, "interface_number" is not a reliable filtering criteria, so we
         # also filter by "usage_page".
-        devices = [device for device in devices if device.get(
-            "usage_page") == MACOS_USAGE_PAGE]
+        mac_filtered_devices = [device for device in devices if device.get(
+             "usage_page") == MACOS_USAGE_PAGE]
+        if len(mac_filtered_devices) != 0:
+            # If we are on a MAC device, we keep the new filtered list
+            devices = mac_filtered_devices
         if len(devices) == 1:
             # No ambiguity, pick the only device
             return devices[0]["path"]

--- a/ledgercomm/interfaces/hid_device.py
+++ b/ledgercomm/interfaces/hid_device.py
@@ -22,6 +22,14 @@ class HIDAPINotInstalledError(ImportError):
         super().__init__("hidapi is not installed, try: 'pip install ledgercomm[hid]'")
 
 
+class CannotFindDeviceError(Exception):
+    """Custom error to be raised when the device can't be found."""
+
+    def __init__(self, vendor_id: int):
+        """Init constructor of CannotFindDeviceError."""
+        super().__init__(f"Can't find Ledger device with vendor_id {hex(vendor_id)}")
+
+
 class HID(Comm):
     """HID class.
 
@@ -93,7 +101,7 @@ class HID(Comm):
             return devices[0]["path"]
 
         if len(devices) > 1:
-            LOG.warn(
+            LOG.warning(
                 "More than one Ledger device with vendor_id %s, will pick the first one",
                 hex(vendor_id))
 
@@ -101,7 +109,7 @@ class HID(Comm):
             devices = sorted(devices, key=lambda device: device["path"])
             return devices[0]["path"]
 
-        raise Exception(f"Can't find Ledger device with vendor_id {hex(vendor_id)}")
+        raise CannotFindDeviceError(vendor_id)
 
     @staticmethod
     def enumerate_devices(vendor_id: int = DEFAULT_VENDOR_ID) -> List[bytes]:

--- a/ledgercomm/interfaces/hid_device.py
+++ b/ledgercomm/interfaces/hid_device.py
@@ -1,6 +1,6 @@
 """ledgercomm.interfaces.hid_device module."""
 
-from typing import List, Tuple, Optional
+from typing import Any, List, Mapping, Optional, Tuple
 
 try:
     import hid
@@ -9,6 +9,14 @@ except ImportError:
 
 from ledgercomm.interfaces.comm import Comm
 from ledgercomm.log import LOG
+
+DEFAULT_VENDOR_ID = 0x2C97
+MACOS_USAGE_PAGE = 0xffa0
+
+
+class HIDAPINotInstalledError(ImportError):
+    def __init__(self):
+        super().__init__("hidapi is not installed, try: 'pip install ledgercomm[hid]'")
 
 
 class HID(Comm):
@@ -35,8 +43,7 @@ class HID(Comm):
     def __init__(self, vendor_id: int = 0x2C97) -> None:
         """Init constructor of HID."""
         if hid is None:
-            raise ImportError("hidapi is not installed, try: "
-                              "'pip install ledgercomm[hid]'")
+            raise HIDAPINotInstalledError()
 
         self.device = hid.device()
         self.path: Optional[bytes] = None
@@ -53,13 +60,44 @@ class HID(Comm):
         """
         if not self.__opened:
             if not self.path:
-                self.path = HID.enumerate_devices(self.vendor_id)[0]
+                self.path = HID._decide_device_path(self.vendor_id)
             self.device.open_path(self.path)
             self.device.set_nonblocking(True)
             self.__opened = True
 
     @staticmethod
-    def enumerate_devices(vendor_id: int = 0x2C97) -> List[bytes]:
+    def _decide_device_path(vendor_id: int = DEFAULT_VENDOR_ID) -> bytes:
+        if hid is None:
+            raise HIDAPINotInstalledError()
+
+        devices: List[Mapping[str, Any]] = list(hid.enumerate(vendor_id, 0))
+        LOG.debug("hid.enumerate(), devices: %s", devices)
+
+        devices = [device for device in devices if device.get("interface_number") == 0]
+        if len(devices) == 1:
+            # No ambiguity, pick the only device
+            return devices[0]["path"]
+
+        # On MacOS, "interface_number" is not a reliable filtering criteria, so we
+        # also filter by "usage_page".
+        devices = [device for device in devices if device.get(
+            "usage_page") == MACOS_USAGE_PAGE]
+        if len(devices) == 1:
+            # No ambiguity, pick the only device
+            return devices[0]["path"]
+
+        if len(devices) > 1:
+            LOG.warn(
+                "More than one Ledger device with vendor_id %s, will pick the first one", hex(vendor_id))
+
+            # First, we sort by "path", so that the order is deterministic
+            devices = sorted(devices, key=lambda device: device["path"])
+            return devices[0]["path"]
+
+        raise Exception(f"Can't find Ledger device with vendor_id {hex(vendor_id)}")
+
+    @staticmethod
+    def enumerate_devices(vendor_id: int = DEFAULT_VENDOR_ID) -> List[bytes]:
         """Enumerate HID devices to find Nano S/X.
 
         Parameters
@@ -73,12 +111,15 @@ class HID(Comm):
             List of paths to HID devices which should be Nano S or Nano X.
 
         """
+        if hid is None:
+            raise HIDAPINotInstalledError()
+
         devices: List[bytes] = []
 
         for hid_device in hid.enumerate(vendor_id, 0):
             if (hid_device.get("interface_number") == 0 or
                     # MacOS specific
-                    hid_device.get("usage_page") == 0xffa0):
+                    hid_device.get("usage_page") == MACOS_USAGE_PAGE):
                 devices.append(hid_device["path"])
 
         assert len(devices) != 0, (

--- a/ledgercomm/interfaces/hid_device.py
+++ b/ledgercomm/interfaces/hid_device.py
@@ -15,7 +15,10 @@ MACOS_USAGE_PAGE = 0xffa0
 
 
 class HIDAPINotInstalledError(ImportError):
+    """Custom error to be raised when hidapi is not installed."""
+
     def __init__(self):
+        """Init constructor of HIDAPINotInstalledError."""
         super().__init__("hidapi is not installed, try: 'pip install ledgercomm[hid]'")
 
 
@@ -40,7 +43,7 @@ class HID(Comm):
 
     """
 
-    def __init__(self, vendor_id: int = 0x2C97) -> None:
+    def __init__(self, vendor_id: int = DEFAULT_VENDOR_ID) -> None:
         """Init constructor of HID."""
         if hid is None:
             raise HIDAPINotInstalledError()


### PR DESCRIPTION
On MacOS >= 13.3.1, device enumeration produces more records, e.g.

```
hid_device {'path': b'DevSrvsID:4294970322', 'vendor_id': 11415, 'product_id': 4117, 'serial_number': '0001', 'release_number': 513, 'manufacturer_string': 'Ledger', 'product_string': 'Nano S', 'usage_page': 65440, 'usage': 1, 'interface_number': 0}
hid_device {'path': b'DevSrvsID:4294970324', 'vendor_id': 11415, 'product_id': 4117, 'serial_number': '0001', 'release_number': 513, 'manufacturer_string': 'Ledger', 'product_string': 'Nano S', 'usage_page': 61904, 'usage': 1, 'interface_number': 0}
```
The order of the enumeration is not deterministic, and, sometimes, `HID.enumerate_devices(self.vendor_id)[0]` might pick an unusable record (not the actual device). In this PR, we implement the device picking logic as a new function, `_decide_device_path`, which handles the behavior of MacOS >= 13.3.1, as well.

The logic of `HID.enumerate_devices()` is left untouched - in case downstream applications were actually relying on the results being a collection of paths, instead of a single path.

## How to test

Clone the repository and, while having a device connected  (with the MultiversX app open - as an example), run the following command:

```
python3 -m ledgercomm.cli.send --hid stdin <<<ed02000000
```

It should work with no error (on all operating systems). Output should be similar to:

```
ledgercomm - DEBUG - => ed02000000
ledgercomm - DEBUG - <= 0102000100140000000000000000 9000
```

Extra references:
 - https://developer.apple.com/forums/thread/728001
 - https://github.com/multiversx/mx-sdk-py-cli/issues/253