### PR TITLE
Make port argument integer in send command

### DIFF
--- a/ledgercomm/cli/send.py
+++ b/ledgercomm/cli/send.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument("--server",
                         help="IP server of the TCP client (default: 127.0.0.1)",
                         default="127.0.0.1")
-    parser.add_argument("--port", help="Port of the TCP client (default: 9999)", default=9999)
+    parser.add_argument("--port", help="Port of the TCP client (default: 9999)", default=9999, type=int)
     parser.add_argument("--startswith",
                         help="Only send APDUs which starts with STARTSWITH (default: None)",
                         default=None)


### PR DESCRIPTION
Fixes error:
```
bash-5.1# ledgercomm-send --port 5001 --startswith "=>" file ./near_apdu.dat 
Traceback (most recent call last):
  File "/usr/bin/ledgercomm-send", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.9/site-packages/ledgercomm/cli/send.py", line 54, in main
    transport = (Transport(interface="hid", debug=True) if args.hid else Transport(
  File "/usr/lib/python3.9/site-packages/ledgercomm/transport.py", line 77, in __init__
    self.com.open()
  File "/usr/lib/python3.9/site-packages/ledgercomm/interfaces/tcp_client.py", line 51, in open
    self.socket.connect((self.server, self.port))
TypeError: an integer is required (got type str)
```